### PR TITLE
Allow other Input implementations

### DIFF
--- a/gui/core/ugui.py
+++ b/gui/core/ugui.py
@@ -114,9 +114,11 @@ class Input:
 # Wrapper for ssd providing buttons and framebuf compatible methods
 class Display:
 
-    def __init__(self, objssd, nxt, sel, prev=None, incr=None, decr=None, encoder=False):
+    def __init__(self, objssd, nxt=None, sel=None, prev=None, incr=None, decr=None, encoder=False, input=None):
         global display, ssd
-        self.ipdev = Input(nxt, sel, prev, incr, decr, encoder)
+        self.ipdev = input
+        if (self.ipdev == None):
+            self.ipdev = Input(nxt, sel, prev, incr, decr, encoder)
         self.height = objssd.height
         self.width = objssd.width
         self._is_grey = False  # Not greyed-out


### PR DESCRIPTION
This enables alternative implementations that could, for instance, use
ESP touchpads:

```
from touch import Touch

prv = buttons.touch_0
sel = buttons.touch_1
nxt = buttons.touch_2

class TouchInput:
    def __init__(self, prv, sel, nxt):
        self._prev = Touch(prv, 0)
        self._sel = Touch(sel, 1)
        self._next = Touch(nxt, 2)

        self._prev.press_func(Screen.ctrl_move, (_PPREV,))
        self._sel.release_func(Screen.sel_ctrl)
        self._next.press_func(Screen.ctrl_move, (_NNEXT,))

    def precision(self, val):
        Screen.redraw_co()

    def adj_mode(self, v=None):
        Screen.redraw_co()

    def is_adjust(self):
        return False

disp = Display(ssd, input=TouchInput(prv, sel, nxt))
```