### PR TITLE
Fully clear the screen

### DIFF
--- a/gui/core/ugui.py
+++ b/gui/core/ugui.py
@@ -164,7 +164,7 @@ class DisplayIP:
     # These methods support greying out color overrides.
     # Clear screen.
     def clr_scr(self):
-        ssd.fill_rect(0, 0, self.width - 1, self.height - 1, color_map[BG])
+        ssd.fill_rect(0, 0, self.width, self.height, color_map[BG])
 
     def rect(self, x1, y1, w, h, color):
         ssd.rect(x1, y1, w, h, self._getcolor(color))


### PR DESCRIPTION
Use the full width and height of the screen to clear it.
Currently, when clearing the screen the width and the height are reduced by one, leaving lines on the screen's bottom and right.
Fox example, with ssd1306 with width 128 and height 64 only first 127 and 63 pixels will be cleared.

Not fully sure about the impact on other screens, but this change got rid of artifacts from previous screens on ssd1306.