### PR TITLE
Add `delta` parameters to sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1867,6 +1867,8 @@ Optional keyword only arguments:
  * `args=[]` A list/tuple of arguments for above callback.
  * `value=0.0` The initial value: slider will be at the bottom (v), left (h).
  * `active=True` Determines whether the control can accept user input.
+ * `min_delta=0.01` Minimim value increment
+ * `max_delta=0.1` Maximum value increment (long button presses)  
 
 Methods:
  * `greyed_out` Optional Boolean argument `val=None`. If `None` returns the

--- a/gui/widgets/sliders.py
+++ b/gui/widgets/sliders.py
@@ -25,8 +25,7 @@ class Slider(LinearIO):
                  callback=dolittle, args=[], value=0.0, active=True,
                  min_delta=0.01, max_delta=0.1):
         width &= 0xfe # ensure divisible by 2
-        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor, 
-            min_delta = min_delta, max_delta = max_delta)
+        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor, min_delta, max_delta)
         super()._set_callbacks(callback, args)
         self.divisions = divisions
         self.legends = legends
@@ -101,8 +100,7 @@ class HorizSlider(LinearIO):
                  callback=dolittle, args=[], value=0.0, active=True,
                  min_delta=0.01, max_delta=0.1):
         height &= 0xfe # ensure divisible by 2
-        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor,
-            min_delta = min_delta, max_delta = max_delta)
+        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor, min_delta, max_delta)
         super()._set_callbacks(callback, args)
         self.divisions = divisions
         self.legends = legends

--- a/gui/widgets/sliders.py
+++ b/gui/widgets/sliders.py
@@ -22,9 +22,11 @@ class Slider(LinearIO):
                  height=100, width=20, divisions=10, legends=None,
                  fgcolor=None, bgcolor=None, fontcolor=None, bdcolor=None,
                  slotcolor=None, prcolor=None,
-                 callback=dolittle, args=[], value=0.0, active=True):
+                 callback=dolittle, args=[], value=0.0, active=True,
+                 min_delta=0.01, max_delta=0.1):
         width &= 0xfe # ensure divisible by 2
-        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor)
+        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor, 
+            min_delta = min_delta, max_delta = max_delta)
         super()._set_callbacks(callback, args)
         self.divisions = divisions
         self.legends = legends
@@ -96,9 +98,11 @@ class HorizSlider(LinearIO):
                  height=20, width=100, divisions=10, legends=None,
                  fgcolor=None, bgcolor=None, fontcolor=None, bdcolor=None,
                  slotcolor=None, prcolor=None,
-                 callback=dolittle, args=[], value=0.0, active=True):
+                 callback=dolittle, args=[], value=0.0, active=True,
+                 min_delta=0.01, max_delta=0.1):
         height &= 0xfe # ensure divisible by 2
-        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor)
+        super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor, value, active, prcolor,
+            min_delta = min_delta, max_delta = max_delta)
         super()._set_callbacks(callback, args)
         self.divisions = divisions
         self.legends = legends


### PR DESCRIPTION
This allows to specify `min_delta` and `max_delta` parameters when creating sliders.
Useful when default increments are too small (when high precision is not necessary).