### PR TITLE
gc.threshold() not available on all ports

### DIFF
--- a/gui/core/ugui.py
+++ b/gui/core/ugui.py
@@ -536,7 +536,8 @@ class Screen:
         while Screen.do_gc:
             await asyncio.sleep_ms(500)
             gc.collect()
-            gc.threshold(gc.mem_free() // 4 + gc.mem_alloc())
+            if hasattr(gc, 'threshold'):
+                gc.threshold(gc.mem_free() // 4 + gc.mem_alloc())
             n += 1
             n &= 0x1F
             _vb and (not n) and print("Free RAM", gc.mem_free())


### PR DESCRIPTION
gc.threshold isn't available on all ports, this PR makes the call in ugui.py conditional.