### PR TITLE
Add Adafruit 1.9" 320x170 Color IPS TFT Display as ADAFRUIT_1_9 displ…

### DIFF
--- a/drivers/st7789/st7789_4bit.py
+++ b/drivers/st7789/st7789_4bit.py
@@ -34,7 +34,7 @@ TDISPLAY = (52, 40, 1)
 PI_PICO_LCD_2 = (0, 0, 1)  # Waveshare Pico LCD 2 determined by Mike Wilson.
 DFR0995 = (34, 0, 0)  # DFR0995 Contributed by @EdgarKluge
 WAVESHARE_13 = (0, 0, 16)  # Waveshare 1.3" 240x240 LCD contributed by Aaron Mittelmeier
-
+ADAFRUIT_1_9 = (35, 0, PORTRAIT) #  320x170 TFT https://www.adafruit.com/product/5394
 
 @micropython.viper
 def _lcopy(dest: ptr16, source: ptr8, lut: ptr16, length: int, gscale: bool):


### PR DESCRIPTION
I tested successfully [Adafruit 1.9" 320x170 Color IPS TFT](https://www.adafruit.com/product/5394) and added a new display type for it.

```python
# snipped from hardware_setup.py
ssd = SSD(
    spi,
    cs=pcs,
    dc=pdc,
    rst=prst,
    height=170,
    width=320,
    display=ADAFRUIT_1_9
)```