### PR TITLE
Synchronous screen refresh triggered by widget draw=True

### DIFF
--- a/gui/widgets/buttons.py
+++ b/gui/widgets/buttons.py
@@ -55,7 +55,7 @@ class Button(Widget):
         h = self.height
         if not self.visible:  # erase the button
             display.usegrey(False)
-            display.fill_rect(x, y, w, h, BGCOLOR)
+            display.fill_rect(x, y, w, h, self.bgcolor)
             return
         super().show()  # Blank rectangle containing button
         if self.shape == CIRCLE:  # Button coords are of top left corner of bounding box


### PR DESCRIPTION
I made tests with enabling synchronous update mode for screen. This can be turned on with Screen.sync_update = True per Screen subclass.

This feature hooks into Widget class draw, which is changed into property and setting draw=True will also trigger screen refresh with Screen.rfsh_start.set()
Currently code includes test printouts and refreshing is tested only with Button class.

Do you think this would be good way to save resources and take screen refresh to control?


Tested with something like this:
```python

class BaseScreen(Screen):
    sync_update = True  # set screen update mode synchronous
    def __init__(self):

        def my_callback(button, arg):
            print('Button pressed', arg)

        super().__init__()
        # verbose default indicates if fast rendering is enabled
        wri = CWriter(ssd, arial10, GREEN, BLACK)

        b = Button(wri, 20, 20, text='Yes', callback=my_callback, args=('Yes',))
        b = Button(wri, 50, 50, text='No', callback=my_callback, args=('No',))
        CloseButton(wri)  # Quit the application

    def after_open(self):
        copy_img_to_mvb('screen1.bin', ssd)
        #blit(ssd,screen1,0,0)
        self.show(True)        
```
giving this kind of output, verifying that screen is updated when focus changes or when button is pressed.

```text
Free RAM 8173472
ref: 41148 us
ref: 42272 us
ref: 42398 us
ref: 41538 us
ref: 40587 us
ref: 41553 us
Button pressed No
```
Ps. Button class seems to reference  BGCOLOR symbol that I cannot find in this project, fixed it to something that will not crash.
